### PR TITLE
Fix kernel_radius function for SSIM scaler

### DIFF
--- a/vsscale/scale.py
+++ b/vsscale/scale.py
@@ -142,7 +142,7 @@ class SSIM(LinearScaler):
 
     @inject_self.property
     def kernel_radius(self) -> int:
-        return self.ref.kernel_radius
+        return self.scaler.kernel_radius
 
 
 @dataclass


### PR DESCRIPTION
The SSIM class does not have a `ref` property, so it throws a runtime error. The change uses the `scaler` property instead, which exists.