### PR TITLE
Get rid of FSRCNNX everywhere

### DIFF
--- a/docs/submodules/funcs.rst
+++ b/docs/submodules/funcs.rst
@@ -6,9 +6,7 @@ Functions
 
     vsscale.funcs.MergeScalers
     vsscale.funcs.ClampScaler
-    vsscale.funcs.MergedFSRCNNX
     vsscale.funcs.UnsharpLimitScaler
-    vsscale.funcs.UnsharpedFSRCNNX
 
 .. automodule:: vsscale.funcs
     :members:

--- a/docs/submodules/shaders.rst
+++ b/docs/submodules/shaders.rst
@@ -6,8 +6,6 @@ Shaders
 
     vsscale.shaders.PlaceboShader
     vsscale.shaders.ShaderFile
-    vsscale.shaders.FSRCNNXShader
-    vsscale.shaders.FSRCNNXShaderT
 
 .. automodule:: vsscale.shaders
     :members:

--- a/vsscale/funcs.py
+++ b/vsscale/funcs.py
@@ -15,12 +15,11 @@ from vstools import (
 )
 
 from .helpers import GenericScaler
-from .shaders import FSRCNNXShader, FSRCNNXShaderT
 
 __all__ = [
     'MergeScalers',
-    'ClampScaler', 'MergedFSRCNNX',
-    'UnsharpLimitScaler', 'UnsharpedFSRCNNX'
+    'ClampScaler',
+    'UnsharpLimitScaler'
 ]
 
 
@@ -245,7 +244,7 @@ class UnsharpLimitScaler(GenericScaler):
     ) -> vs.VideoNode:
         width, height = self._wh_norm(clip, width, height)
 
-        fsrcnnx = self.ref_scaler.scale(clip, width, height, shift, **kwargs)
+        ref_scaler = self.ref_scaler.scale(clip, width, height, shift, **kwargs)
 
         if isinstance(self.reference, vs.VideoNode):
             smooth = self.reference  # type: ignore
@@ -257,43 +256,21 @@ class UnsharpLimitScaler(GenericScaler):
 
         assert smooth
 
-        check_ref_clip(fsrcnnx, smooth)
+        check_ref_clip(ref_scaler, smooth)
 
         smooth_sharp = self.unsharp_func(smooth, *self.args, **self.kwargs)
 
         if isinstance(self.merge_mode, LimitFilterMode):
-            return limit_filter(smooth, fsrcnnx, smooth_sharp, self.merge_mode)
+            return limit_filter(smooth, ref_scaler, smooth_sharp, self.merge_mode)
 
         if self.merge_mode:
-            return MeanMode.MEDIAN(smooth, fsrcnnx, smooth_sharp)
+            return MeanMode.MEDIAN(smooth, ref_scaler, smooth_sharp)
 
-        return combine([smooth, fsrcnnx, smooth_sharp], ExprOp.MIN)
+        return combine([smooth, ref_scaler, smooth_sharp], ExprOp.MIN)
 
     @property
     def kernel_radius(self) -> int:
         if self._reference:
             return max(self._reference.kernel_radius, self.ref_scaler.kernel_radius)
+
         return self.ref_scaler.kernel_radius
-
-
-@dataclass
-class MergedFSRCNNX(ClampScaler):
-    """Clamped FSRCNNX Scaler."""
-
-    ref_scaler: FSRCNNXShaderT = field(default_factory=lambda: FSRCNNXShader.x56, kw_only=True)
-
-
-class UnsharpedFSRCNNX(UnsharpLimitScaler):
-    """Clamped FSRCNNX Scaler with an unsharp mask."""
-
-    def __init__(
-        self,
-        unsharp_func: Callable[
-            Concatenate[vs.VideoNode, P], vs.VideoNode
-        ] = partial(unsharp_masked, radius=2, strength=65),
-        merge_mode: LimitFilterMode | bool = True,
-        reference: ScalerT | vs.VideoNode = Nnedi3(0, opencl=None),
-        ref_scaler: ScalerT = FSRCNNXShader.x56,
-        *args: P.args, **kwargs: P.kwargs
-    ) -> None:
-        super().__init__(ref_scaler, unsharp_func, merge_mode, reference, *args, **kwargs)

--- a/vsscale/funcs.py
+++ b/vsscale/funcs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Concatenate, Literal, cast
 

--- a/vsscale/shaders.py
+++ b/vsscale/shaders.py
@@ -17,8 +17,6 @@ __all__ = [
     'PlaceboShader',
 
     'ShaderFile',
-
-    'FSRCNNXShader', 'FSRCNNXShaderT'
 ]
 
 
@@ -120,10 +118,6 @@ class ShaderFile(ShaderFileBase):
     if not TYPE_CHECKING:
         CUSTOM = 'custom'
 
-    FSRCNNX_x8 = 'FSRCNNX_x2_8-0-4-1.glsl'
-    FSRCNNX_x16 = 'FSRCNNX_x2_16-0-4-1.glsl'
-    FSRCNNX_x56 = 'FSRCNNX_x2_56-16-4-1.glsl'
-
     SSIM_DOWNSCALER = 'SSimDownscaler.glsl'
     SSIM_SUPERSAMPLER = 'SSimSuperRes.glsl'
 
@@ -165,24 +159,3 @@ class ShaderFile(ShaderFileBase):
             return mpv_dir
 
         raise FileWasNotFoundError(f'"{file_name}" could not be found!', str(ShaderFile.CUSTOM))
-
-
-class FSRCNNXShader(PlaceboShaderBase):
-    """Defaults FSRCNNX shaders shipped with vsscale."""
-
-    shader_file = ShaderFile.FSRCNNX_x56
-
-    @dataclass
-    class x8(PlaceboShaderBase):
-        shader_file = ShaderFile.FSRCNNX_x8
-
-    @dataclass
-    class x16(PlaceboShaderBase):
-        shader_file = ShaderFile.FSRCNNX_x16
-
-    @dataclass
-    class x56(PlaceboShaderBase):
-        shader_file = ShaderFile.FSRCNNX_x56
-
-
-FSRCNNXShaderT = type[PlaceboShaderBase] | PlaceboShaderBase  # type: ignore


### PR DESCRIPTION
I don't know how much you care about adding a deprecation warning for these, so just making it a PR.

Note that from what I understand, these shouldn't even run because the shades aren't packaged with the package anymore.